### PR TITLE
Fix Electron 20+ build

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -14,6 +14,9 @@
           "sources": [
             "src/keyboard-layout-manager-mac.mm",
           ],
+          'xcode_settings': {
+            'CLANG_CXX_LANGUAGE_STANDARD': 'c++17',
+          },
           "link_settings": {
             "libraries": [
               "-framework", "AppKit"
@@ -46,6 +49,9 @@
         ['OS=="linux"', {
           "sources": [
             "src/keyboard-layout-manager-linux.cc",
+          ],
+          'cflags_cc!': [
+            '-std=gnu++14'
           ],
           "link_settings": {
             "libraries": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -653,6 +653,7 @@
     },
     "jasmine-node": {
       "version": "git+ssh://git@github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
+      "integrity": "sha512-OvqXUF5P3qkt6qYIkMeTRfBRp0V2BcQYhmUfax40vP0CcjxNbXy1hKaxTj/fidXU72bp/zf8UEJd5DqZI+Ojlg==",
       "dev": true,
       "from": "jasmine-node@git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
       "requires": {


### PR DESCRIPTION
electron 20+(or one of the versions around it?) build against c++17 but the config's set c++ standard to gnu++14 which causes build failures.

Unsetting the option lets the compiler pick and it will default to a higher version.